### PR TITLE
Add support for Artifactory Pro edition

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -200,6 +200,14 @@ class artifactory::config {
     }
   }
 
+  if ($::artifactory::license_key) {
+    file { "${::artifactory::artifactory_home}/etc/artifactory.lic":
+      ensure  => file,
+      content => $::artifactory::license_key,
+      mode    => '0664',
+    }
+  }
+
   if ($::artifactory::db_automate) and ($::artifactory::db_type == 'mysql') {
     include systemd::systemctl::daemon_reload
     include ::artifactory::mysql

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,12 +3,15 @@
 #
 #
 class artifactory(
+  Enum['oss', 'pro', 'enterprise'] $edition                                                = 'oss',
   Boolean $manage_java                                                                     = true,
   Boolean $manage_repo                                                                     = true,
   Boolean $use_temp_db_secrets                                                             = true,
   String $yum_name                                                                         = 'bintray-jfrog-artifactory-rpms',
   String $yum_baseurl                                                                      = 'http://jfrog.bintray.com/artifactory-rpms',
+  String $yum_baseurl_pro                                                                  = 'http://jfrog.bintray.com/artifactory-pro-rpms',
   String $package_name                                                                     = 'jfrog-artifactory-oss',
+  String $package_name_pro                                                                 = 'jfrog-artifactory-pro',
   String $package_version                                                                  = 'present',
   String $artifactory_home                                                                 = '/var/opt/jfrog/artifactory',
   Optional[String] $root_password                                                          = 'password',
@@ -26,6 +29,7 @@ class artifactory(
   Optional[String] $binary_provider_filesystem_dir                                         = undef,
   Optional[String] $binary_provider_cache_dir                                              = undef,
   Optional[String] $master_key                                                             = undef,
+  Optional[String] $license_key                                                            = undef,
 ) {
 
   $service_name = 'artifactory'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,16 @@
 # This class is called from artifactory for install.
 #
 class artifactory::install {
-  package { $::artifactory::package_name:
+  case $artifactory::edition {
+    'pro' : {
+      $_package = $artifactory::package_name_pro
+    }
+    default : {
+      $_package = $artifactory::package_name
+    }
+  }
+
+  package { $_package:
     ensure  => $::artifactory::package_version,
   }
 }

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -4,9 +4,18 @@
 #
 class artifactory::yum {
   if $::artifactory::manage_repo {
+    case $artifactory::edition {
+      'pro' : {
+        $_url = $artifactory::yum_baseurl_pro
+      }
+      default : {
+        $_url = $artifactory::yum_baseurl
+      }
+    }
+
     # Add the jfrog yum repo
     yumrepo { $::artifactory::yum_name:
-      baseurl  => $::artifactory::yum_baseurl,
+      baseurl  => $_url,
       descr    => $::artifactory::yum_name,
       gpgcheck => 0,
       enabled  => 1,


### PR DESCRIPTION
Hi @bryanjbelanger,

as discussed in https://github.com/fervidus/artifactory_pro/issues/1 this is a first step in an attempt to merge all three artifactory modules. This PR adds support for the Pro edition through new parameters `$edition` and `$license_key`, which are working as expected:

```
class { '::artifactory':
  binary_provider_type          => 'filesystem',
  binary_provider_cache_maxsize => 1073741824,
  db_url                        => 'jdbc:derby:{db.home};create=true',
  db_type                       => 'derby',
  edition                       => 'pro',
  license_key                   => 'abcdefg1234567890',
  manage_java                   => false,
  manage_repo                   => true,
  package_version               => '6.11.3',
  pool_max_active               => 100,
  pool_max_idle                 => 10,
}
```

```
Info: Applying configuration version '1572204691'
Notice: /Stage[main]/Artifactory::Yum/Yumrepo[bintray-jfrog-artifactory-rpms]/ensure: created (corrective)
Info: Yumrepo[bintray-jfrog-artifactory-rpms](provider=inifile): changing mode of /etc/yum.repos.d/bintray-jfrog-artifactory-rpms.repo from 600 to 644
Notice: /Stage[main]/Artifactory::Install/Package[jfrog-artifactory-pro]/ensure: created
Notice: /Stage[main]/Artifactory::Config/File[/var/opt/jfrog/artifactory/etc/binarystore.xml]/content: content changed '{md5}c36de119f10c4ee544ddb4e0dcd7f753' to '{md5}3d29aaf407c2af8ea5188060a7777e23' (corrective)
Info: /Stage[main]/Artifactory::Config/File[/var/opt/jfrog/artifactory/etc/binarystore.xml]: Scheduling refresh of Class[Artifactory::Service]
Info: Class[Artifactory::Service]: Scheduling refresh of Service[artifactory]
Notice: /Stage[main]/Artifactory::Service/Service[artifactory]/ensure: ensure changed 'stopped' to 'running' (corrective)
Info: /Stage[main]/Artifactory::Service/Service[artifactory]: Unscheduling refresh on Service[artifactory]
Notice: Applied catalog in 72.87 seconds
```
The value of `$edition` defaults to `oss`, so it won't change anything for existing installations.

This PR does not add much, but it should already be sufficient to deprecate fervidus/artifactory_pro.

(Side note: I'd like to rework the repository handling to avoid having to add new parameters for every edition, but in an attempt to keep this PR small and clean I'll provide this in a new PR some time later.)