### PR TITLE
[URGENT] Fix two regressions in version 3.0.0

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -66,12 +66,13 @@ class artifactory::config {
 
   # Determine the directory for the chosen binary provider.
   if ($binary_provider_type == 'file-system') and ! $::artifactory::binary_provider_filesystem_dir {
-      $mapped_provider_filesystem_dir = 'filestore'
-  } else {
-      $mapped_provider_filesystem_dir = $::artifactory::binary_provider_filesystem_dir
-  }
-  if $::artifactory::binary_provider_base_data_dir {
-    $binary_provider_filesystem_dir = "${::artifactory::binary_provider_base_data_dir}/${mapped_provider_filesystem_dir}"
+    if $::artifactory::binary_provider_base_data_dir {
+      $binary_provider_filesystem_dir = "${::artifactory::binary_provider_base_data_dir}/filestore"
+    } else {
+      $binary_provider_filesystem_dir = undef
+    }
+  } elsif ($binary_provider_type == 'file-system') and $::artifactory::binary_provider_filesystem_dir {
+    $binary_provider_filesystem_dir = $::artifactory::binary_provider_filesystem_dir
   } else {
     $binary_provider_filesystem_dir = undef
   }

--- a/spec/classes/artifactory_spec.rb
+++ b/spec/classes/artifactory_spec.rb
@@ -169,18 +169,76 @@ describe 'artifactory' do
           }
         end
 
-        context 'artifactory class with version specified' do
+        context 'running a legacy version (pre v7)' do
           let(:params) do
             {
-              'package_version' => '5.9.1',
+              'package_version' => '6.0.0',
             }
           end
 
           it { is_expected.to compile.with_all_deps }
           it {
             is_expected.to contain_package('jfrog-artifactory-oss').with(
-              'ensure' => '5.9.1',
+              'ensure' => '6.0.0',
             )
+          }
+          it {
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/binarystore.xml').with_content(%r{chain template="file-system"})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/binarystore.xml').without_content(%r{<provider id="file-system" type="file-system">})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/binarystore.xml').without_content(%r{<fileStoreDir>})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/binarystore.xml').without_content(%r{<baseDataDir>})
+          }
+        end
+
+        context 'running a current version' do
+          let(:params) do
+            {
+              'package_version' => '7.4.3',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_package('jfrog-artifactory-oss').with(
+              'ensure' => '7.4.3',
+            )
+          }
+          it {
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').with_content(%r{chain template="file-system"})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').without_content(%r{<provider id="file-system" type="file-system">})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').without_content(%r{<fileStoreDir>})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').without_content(%r{<baseDataDir>})
+          }
+        end
+
+        context 'running a current version with a custom binary filesystem dir' do
+          let(:params) do
+            {
+              'package_version' => '7.4.3',
+              'binary_provider_filesystem_dir' => '/opt/artifactory-filestore',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').with_content(%r{<provider id="file-system" type="file-system">})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').with_content(%r{<fileStoreDir>/opt/artifactory-filestore</fileStoreDir>})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').without_content(%r{<baseDataDir>})
+          }
+        end
+
+        context 'running a current version with a custom binary base data dir' do
+          let(:params) do
+            {
+              'package_version' => '7.4.3',
+              'binary_provider_base_data_dir' => '/opt/artifactory-data',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').with_content(%r{<baseDataDir>/opt/artifactory-data</baseDataDir>})
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/artifactory/binarystore.xml').with_content(%r{<fileStoreDir>/opt/artifactory-data/filestore</fileStoreDir>})
           }
         end
       end

--- a/templates/binarystore.xml.epp
+++ b/templates/binarystore.xml.epp
@@ -33,33 +33,33 @@
 
 <config version="1">
     <chain template="<%= $binary_provider_type %>"/>
-<% if $binary_provider_type == 'filesystem'
+<% if $binary_provider_type == 'file-system'
     and ($binary_provider_base_data_dir or $binary_provider_filesystem_dir)
-  or $binary_provider_type == 'cachedFS'
+  or $binary_provider_type == 'cache-fs'
     and ($binary_provider_cache_dir or $binary_provider_cache_maxsize) { -%>
     <provider id="<%= $binary_provider_type %>" type="<%= $binary_provider_type %>">
-<% if $binary_provider_type == 'filesystem'
+<% if $binary_provider_type == 'file-system'
   and $binary_provider_base_data_dir { -%>
         <baseDataDir><%= $binary_provider_base_data_dir %></baseDataDir>
 <% } -%>
-<% if $binary_provider_type == 'filesystem'
+<% if $binary_provider_type == 'file-system'
   and $binary_provider_filesystem_dir { -%>
         <fileStoreDir><%= $binary_provider_filesystem_dir %></fileStoreDir>
 <% } -%>
-<% if $binary_provider_type == 'cachedFS'
+<% if $binary_provider_type == 'cache-fs'
   and $binary_provider_cache_maxsize { -%>
         <maxCacheSize><%= $binary_provider_cache_maxsize %></maxCacheSize>
 <% } -%>
-<% if $binary_provider_type == 'cachedFS'
+<% if $binary_provider_type == 'cache-fs'
   and $binary_provider_cache_dir { -%>
         <cacheProviderDir><%= $binary_provider_cache_dir %></cacheProviderDir>
 <% } -%>
     </provider>
-<% } elsif $binary_provider_type == 'fullDb' { -%>
+<% } elsif $binary_provider_type == 'full-db' { -%>
     <provider id="cache-fs" type="cache-fs">
       <provider id="blob" type="blob"/>
     </provider>
-<% } elsif $binary_provider_type == 'fullDbDirect' { -%>
+<% } elsif $binary_provider_type == 'full-db-direct' { -%>
     <provider id="blob" type="blob"/>
 <% } -%>
 </config>


### PR DESCRIPTION
Unfortunately, the changes in PR #11 introduced two regressions:

1. The conditions in `binarystore.xml.epp` still used the old values and as a result `$binary_provider_filesystem_dir` was never used.

2. The logic in `config.pp` was incorrectly migrated from the EPP template to the manifest in revision 4a07e9c71c369286dfb763dccba6ce5da726635c, which resulted in unexpected binarystore configuration.

Besides fixing these two regressions I've added a few new tests to verify that the binarystore configuration contains the expected options. It should make it more difficult to break this again in the future. :)

If you accept this PR, then please create a new release on GitHub and on Puppet Forge, because loosing the binarystore configuration is a critical bug. 