### PR TITLE
Add config file ownership change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ Optional setting for the location of the cache. This should be set to your $ARTI
 
 Optional setting for the master key that Artifactory uses to connect to the database. If specified, it ensures that if your node terminates, a new one can be spun up that can connect to the same database as before. Otherwise, Artifactory will generate a new master key on first run.
 
+##### `config_owner`
+
+Optional argument to set the ownership of the configuration files.
+
+##### `config_group`
+
+Optional argument to set the group of the configuration files.
+
 ## Limitations
 
 This module has been tested on:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -132,8 +132,8 @@ class artifactory::config {
       if $::artifactory::use_temp_db_secrets {
         file { $_secrets_dir:
           ensure => directory,
-          owner  => 'artifactory',
-          group  => 'artifactory',
+          owner  => $::artifactory::config_owner,
+          group  => $::artifactory::config_group,
         }
 
         file { "${$_secrets_dir}/.temp.db.properties":
@@ -156,8 +156,8 @@ class artifactory::config {
             }
           ),
           mode    => '0640',
-          owner   => 'artifactory',
-          group   => 'artifactory',
+          owner   => $::artifactory::config_owner,
+          group   => $::artifactory::config_group,
         }
 
         # Setup a symlink for legacy versions.
@@ -180,8 +180,8 @@ class artifactory::config {
           file { "${::artifactory::artifactory_home}/etc/db.properties":
             ensure => file,
             mode   => '0640',
-            owner  => 'artifactory',
-            group  => 'artifactory',
+            owner  => $::artifactory::config_owner,
+            group  => $::artifactory::config_group,
           }
           file { "${::artifactory::artifactory_home}/etc/storage.properties":
             ensure => link,
@@ -238,6 +238,8 @@ class artifactory::config {
   # Configure the filestore.
   file { "${_config_dir}/binarystore.xml":
     ensure  => file,
+    owner   => $::artifactory::config_owner,
+    group   => $::artifactory::config_group,
     content => epp(
       'artifactory/binarystore.xml.epp',
       {
@@ -255,16 +257,16 @@ class artifactory::config {
   if ($::artifactory::master_key) {
     file { $_security_dir:
       ensure => directory,
-      owner  => 'artifactory',
-      group  => 'artifactory',
+      owner  => $::artifactory::config_owner,
+      group  => $::artifactory::config_group,
     }
 
     file { "${_security_dir}/master.key":
       ensure  => file,
       content => $::artifactory::master_key,
       mode    => '0640',
-      owner   => 'artifactory',
-      group   => 'artifactory',
+      owner   => $::artifactory::config_owner,
+      group   => $::artifactory::config_group,
       notify  => Class['artifactory::service'],
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ class artifactory(
   String $package_name_pro                                                                 = 'jfrog-artifactory-pro',
   String $package_version                                                                  = 'present',
   String $artifactory_home                                                                 = '/var/opt/jfrog/artifactory',
+  Optional[String] $config_owner                                                           = 'artifactory',
+  Optional[String] $config_group                                                           = 'artifactory',
   Optional[String] $root_password                                                          = 'password',
   Optional[String] $jdbc_driver_url                                                        = undef,
   Optional[Enum['derby', 'mariadb', 'mssql', 'mysql', 'oracle', 'postgresql']] $db_type    = undef,


### PR DESCRIPTION
Artifactory and Puppet ending up flipping the ownership of 'binarystore.xml'.
This resulted in a restart of the service every run, since the user and group might change in the future I made them configurable.